### PR TITLE
Added fix for rpc usecase where mE sends rpc request and uE responds

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -46,7 +46,7 @@ class UpClientVSomeip(ConanFile):
         self.requires("protobuf/3.21.12")
         self.requires("gtest/1.14.0")
         self.requires("rapidjson/cci.20230929")
-        # self.requires("vsomeip/3.4.10") // This shall be enabled once, conan.io starts supporting vsomeip library
+        # self.requires("vsomeip/3.4.10") #This shall be enabled once, conan.io starts supporting vsomeip library
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/src/SomeipRouter.cpp
+++ b/src/SomeipRouter.cpp
@@ -263,6 +263,20 @@ bool SomeipRouter::routeOutboundMsg(const UMessage &umsg) {
         }
         break;
         case UMessageType::UMESSAGE_TYPE_RESPONSE:
+            if (umsg.attributes().sink().entity().has_id()) {
+                ueId =  static_cast<uint16_t> (umsg.attributes().sink().entity().id());
+            }
+            else {
+                SPDLOG_ERROR("{} Sink URI entityId is not found for outbound message.", __FUNCTION__);
+                return false;
+            }
+
+            hptr = getHandler(ueId);
+            if (nullptr == hptr) {
+                SPDLOG_ERROR("{} No service handler found for UEID[0x{:x}]", __FUNCTION__, ueId);
+                return false;
+            }
+        break;
         /* Fall through expected */
         case UMessageType::UMESSAGE_TYPE_PUBLISH: {
             if (umsg.attributes().source().entity().has_id()) {


### PR DESCRIPTION
Background:
mE sends rpc request to uE and uE sends UMessage as a response. When UMessage response is received in up-client-vsomeip-cpp, UMessage Attribute Sink Entity ID needs to be checked and handler needs to be processed. In earlier implementation, source entity id was checked instead of sink entity id and that was working because source and sink were same in previous implementation.

What is Fixed:
For rpc response, UMessage attribute sink ID is checked instead of checking source ID.